### PR TITLE
Disable PIN authentication if the user's homedir is on a locked ecryptfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mnt"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1587ebb20a5b04738f16cffa7e2526f1b8496b84f92920facd518362ff1559eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +731,7 @@ dependencies = [
  "libc",
  "locale_config",
  "log",
+ "mnt",
  "nix 0.29.0",
  "pam-sys",
  "pinpam-core",

--- a/pinpam-pam/Cargo.toml
+++ b/pinpam-pam/Cargo.toml
@@ -21,6 +21,7 @@ rust-i18n = { workspace = true }
 locale_config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+mnt = "0.3.*"
 # Add PAM bindings when available
 # pam-sys = "1.0"  # or whatever PAM crate you prefer
 

--- a/pinpam-pam/locales/en.yml
+++ b/pinpam-pam/locales/en.yml
@@ -1,6 +1,7 @@
 _version: 1
 auth_failure: "Incorrect PIN"
 pin_auth_unavail: "PIN authentication currently unavailable"
+pin_auth_unavail_ecryptfs: "PIN authentication unavailable (home directory encrypted)"
 pin_not_conf_for_user: "PIN authentication is not configured"
 account_locked: "PIN locked (too many failures)"
 pin_prompt: "PIN: "

--- a/pinpam-pam/locales/sk.yml
+++ b/pinpam-pam/locales/sk.yml
@@ -1,6 +1,7 @@
 _version: 1
 auth_failure: "Nesprávny PIN"
 pin_auth_unavail: "Prihlásenie PINom momentálne nedostupné"
+pin_auth_unavail_ecryptfs: "Prihlásenie PINom nedostupné (zašifrovaný domovský adresár)"
 pin_not_conf_for_user: "Prihlásenie PINom nie je aktivované"
 account_locked: "PIN zablokovaný (priveľa nesprávnych pokusov)"
 pin_prompt: "PIN: "


### PR DESCRIPTION
This is needed on systems which employ home directory encryption via ecryptfs. We cannot allow PIN authentication there, because the user's ecryptfs won't unlock with just a PIN and consequently, this could leave them "stranded" on the login screen without a usable session. They could fix this by temporarily reverting to password authentication manually, but most users won't guess that this is what's needed. Testing this on Linux Mint with ecryptfs, the session starts and the immediately logs out, which is utterly confusing to an ordinary user (the session just appears to crash instantly).
In a sense, with ecryptfs deployed, this works similarly to how macOS fingerprint authentication works. On initial startup, fingerprint is disabled and the system requires a password to perform the initial FDE unlock. Only afterwards does fingerprint auth become available.